### PR TITLE
fix ci test command, fix make targets, add two dummy tests

### DIFF
--- a/{{cookiecutter.plugin_name}}/.github/workflows/lint-and-test.yml
+++ b/{{cookiecutter.plugin_name}}/.github/workflows/lint-and-test.yml
@@ -26,4 +26,4 @@ jobs:
         with:
           python-version: 3.8
       - uses: actions/checkout@v2
-      - run: pytest
+      - run: make test

--- a/{{cookiecutter.plugin_name}}/Makefile
+++ b/{{cookiecutter.plugin_name}}/Makefile
@@ -11,12 +11,12 @@ test:
 
 # ---- Installation ---
 
-install: install-deps install-flexmeasures
+install: install-deps install-{cookiecutter.plugin_slug}
 
 install-for-dev:
 	make freeze-deps
 	pip-sync requirements/app.txt requirements/dev.txt requirements/test.txt
-	make install-flexmeasures
+	make install-{cookiecutter.plugin_slug}
 
 install-deps:
 	make install-pip-tools

--- a/{{cookiecutter.plugin_name}}/{{cookiecutter.module_name}}/__init__.py
+++ b/{{cookiecutter.plugin_name}}/{{cookiecutter.module_name}}/__init__.py
@@ -1,5 +1,7 @@
 """
 The __init__ for the {{cookiecutter.plugin_name}} FlexMeasures plugin.
+
+FlexMeasures registers the BluePrint objects it finds in here.
 """
 
 __version__ = "Unknown version"

--- a/{{cookiecutter.plugin_name}}/{{cookiecutter.module_name}}/api/tests/test_api.py
+++ b/{{cookiecutter.plugin_name}}/{{cookiecutter.module_name}}/api/tests/test_api.py
@@ -1,0 +1,2 @@
+def test_dummy():
+    assert 1 == 1

--- a/{{cookiecutter.plugin_name}}/{{cookiecutter.module_name}}/cli/tests/test_cli.py
+++ b/{{cookiecutter.plugin_name}}/{{cookiecutter.module_name}}/cli/tests/test_cli.py
@@ -1,0 +1,2 @@
+def test_dummy():
+    assert 1 == 1


### PR DESCRIPTION
Reason for dummy tests: if no tests are run, then the pytest command returns a non-zero error code. Opinions differ if that is the best way, but it has been decided, as it could be an accident in filtering tests or so.